### PR TITLE
Set a more restrictive cidr range, no public ingressing

### DIFF
--- a/nat_instances/main.tf
+++ b/nat_instances/main.tf
@@ -42,6 +42,7 @@ resource "aws_security_group" "this" {
 
 resource "aws_security_group_rule" "allow_from_vpc" {
   type              = "ingress"
+  description       = "Allow inbound traffic from VPC"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
@@ -51,10 +52,11 @@ resource "aws_security_group_rule" "allow_from_vpc" {
 
 resource "aws_security_group_rule" "allow_wan_outbound" {
   type              = "egress"
+  description       = "Allow outbound wan traffic"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [data.aws_vpc.this.cidr_block]
   security_group_id = aws_security_group.this.id
 }
 

--- a/subnets.tf
+++ b/subnets.tf
@@ -41,7 +41,7 @@ resource "aws_network_acl_rule" "allow_all_inbound" {
   egress         = false
   protocol       = -1
   rule_action    = "allow"
-  cidr_block     = "0.0.0.0/0"
+  cidr_block     = aws_vpc.this.cidr_block
 }
 
 resource "aws_network_acl_rule" "allow_all_outbound" {
@@ -52,7 +52,7 @@ resource "aws_network_acl_rule" "allow_all_outbound" {
   egress         = true
   protocol       = -1
   rule_action    = "allow"
-  cidr_block     = "0.0.0.0/0"
+  cidr_block     = aws_vpc.this.cidr_block
 }
 
 resource "aws_network_acl_association" "this" {


### PR DESCRIPTION
Fix the following tfsec report : 

```
Results #1-7 CRITICAL Network ACL rule allows ingress from public internet. (7 similar results)
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  subnets.tf:44
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   36    resource "aws_network_acl_rule" "allow_all_inbound" {
   37      for_each = aws_network_acl.this
   38    
   39      network_acl_id = each.value.id
   40      rule_number    = 100
   41      egress         = false
   42      protocol       = -1
   43      rule_action    = "allow"
   44  [   cidr_block     = "0.0.0.0/0" ("0.0.0.0/0")
   45    }
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Individual Causes
  - subnets.tf:36-45 (aws_network_acl_rule.allow_all_inbound[0])
  - subnets.tf:36-45 (aws_network_acl_rule.allow_all_inbound[6])
  - subnets.tf:36-45 (aws_network_acl_rule.allow_all_inbound[2])
  - subnets.tf:36-45 (aws_network_acl_rule.allow_all_inbound[1])
  - subnets.tf:36-45 (aws_network_acl_rule.allow_all_inbound[4])
  - subnets.tf:36-45 (aws_network_acl_rule.allow_all_inbound[3])
  - subnets.tf:36-45 (aws_network_acl_rule.allow_all_inbound[5])
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
          ID aws-ec2-no-public-ingress-acl
      Impact The ports are exposed for ingressing data to the internet
  Resolution Set a more restrictive cidr range

  More Information
  - https://aquasecurity.github.io/tfsec/v1.28.5/checks/aws/ec2/no-public-ingress-acl/
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule#cidr_block
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
```